### PR TITLE
Packages also *.cjs and *.mjs files

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function createPackage(name, packageJson) {
       }
       shellCommands = shellCommands.concat([
         "npm install --production",
-        "zip -rq package.zip *.js node_modules lib app",
+        "zip -rq package.zip *.cjs *.js *.mjs node_modules lib app",
         `cp package.zip ${packagePath}`,
       ])
       jake.exec(shellCommands, {printStdout: true, printStderr: true}, () => {


### PR DESCRIPTION
The new file extensions are a common way to declare the module type of the source (CommonJS (*.cjs) vs. ECMAScript (*.mjs)), overriding the `type` that is declared in package.json (which is sometimes not even present).